### PR TITLE
Do not set movie strip filter to Subsampling 3x3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2568,7 +2568,6 @@ class SEQUENCER_OT_generate_movie(Operator):
                                 use_framerate=False,
                             )
                             strip = scene.sequence_editor.active_strip
-                            strip.transform.filter = "SUBSAMPLING_3x3"
                             scene.sequence_editor.active_strip = strip
                             strip.name = str(seed) + "_" + prompt
                             strip.use_proxy = True


### PR DESCRIPTION
Several reasons:
1) Extensions says it works starting with blender 3.4, but Subsampling 3x3 filter was only added in blender 3.5.
2) It is actually removed (well, renamed to BOX) in blender 4.1.
3) It only ever does anything useful when movie strip is scaled _down_ by more than 2x. When scaling up, it does not look good at all. Starting with Blender 4.1, default filter is "AUTO" which does more better thing no matter what is the scaling factor.